### PR TITLE
Use privileged access where required when using a security manager.

### DIFF
--- a/src/main/java/org/apache/log4j/Appenders.java
+++ b/src/main/java/org/apache/log4j/Appenders.java
@@ -1,0 +1,174 @@
+package org.apache.log4j;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+
+import org.apache.log4j.spi.AppenderAttachable;
+import org.jboss.logmanager.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Appenders {
+
+    private static final org.jboss.logmanager.Logger.AttachmentKey<CopyOnWriteArrayList<Appender>> APPENDERS_KEY = new org.jboss.logmanager.Logger.AttachmentKey<CopyOnWriteArrayList<Appender>>();
+
+    /**
+     * Attaches an appender to the logger.
+     *
+     * @param logger   the logger to attach the appender to.
+     * @param appender the appender to attach.
+     */
+    public static void attachAppender(final Logger logger, final Appender appender) {
+        Handler[] oldHandlers;
+        Handler[] newHandlers;
+        CAS:
+        do {
+            oldHandlers = logger.getHandlers();
+            for (Handler handler : oldHandlers) {
+                if (handler instanceof JBossAppenderHandler) {
+                    break CAS;
+                }
+            }
+            final int size = oldHandlers.length;
+            newHandlers = Arrays.copyOf(oldHandlers, size + 1);
+            if (System.getSecurityManager() == null) {
+                newHandlers[size] = new JBossAppenderHandler(logger);
+            } else {
+                newHandlers[size] = AccessController.doPrivileged(new PrivilegedAction<Handler>() {
+                    @Override
+                    public Handler run() {
+                        return new JBossAppenderHandler(logger);
+                    }
+                });
+            }
+        } while (!logger.compareAndSetHandlers(oldHandlers, newHandlers));
+        getAppenderList(logger).addIfAbsent(appender);
+    }
+
+    /**
+     * Retrieves all the appenders that are associated with this logger only.
+     *
+     * @param logger the logger to retrieve the appenders on.
+     *
+     * @return a collection of the appenders.
+     */
+    public static List<Appender> getAppenders(final Logger logger) {
+        List<Appender> appenders = getAppenderList(logger);
+        if (appenders == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<Appender>(appenders);
+    }
+
+    /**
+     * Retrieves a single appender based on the appender name.
+     *
+     * @param logger the logger to check fot the appender.
+     * @param name   the name of the appender.
+     *
+     * @return the appender or {@code null} if the appender was not found.
+     */
+    public static Appender getAppender(final Logger logger, final String name) {
+        Appender result = null;
+        if (name != null) {
+            List<Appender> appenders = getAppenders(logger);
+            for (Appender appender : appenders) {
+                if (name.equals(appender.getName())) {
+                    result = appender;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks the logger to see if the appender is attached.
+     *
+     * @param logger   the logger to check for the appender.
+     * @param appender the appender to check for.
+     *
+     * @return {@code true} if the appender is found on the logger, otherwise {@code false}.
+     */
+    public static boolean isAppenderAttached(final Logger logger, final Appender appender) {
+        return getAppenders(logger).contains(appender);
+    }
+
+    /**
+     * Removes all the appenders from the logger and returns the all the appenders that were removed.
+     *
+     * @param logger the logger to remove the appenders from.
+     *
+     * @return a collection of the appenders that were removed.
+     */
+    public static List<Appender> removeAllAppenders(final Logger logger) {
+        List<Appender> result = Collections.emptyList();
+        final List<Appender> currentAppenders = getAppenderList(logger);
+        if (currentAppenders != null && !currentAppenders.isEmpty()) {
+            result = new ArrayList<Appender>(currentAppenders);
+            currentAppenders.clear();
+        }
+        return result;
+    }
+
+    /**
+     * Removes a single appender from the logger.
+     *
+     * @param logger   the logger to remove the appender from.
+     * @param appender the appender to remove.
+     *
+     * @return {@code true} if the appender wasn't {@code null} and was successfully removed, otherwise {@code false}.
+     */
+    public static boolean removeAppender(final Logger logger, final Appender appender) {
+        boolean result = false;
+        final List<Appender> currentAppenders = getAppenderList(logger);
+        if (currentAppenders != null) {
+            result = currentAppenders.remove(appender);
+        }
+        return result;
+    }
+
+    /**
+     * Closes the appenders attached to the logger if the appenders are an instance of {@link org.apache.log4j.spi.AppenderAttachable}.
+     *
+     * @param logger the logger to close the appenders on.
+     */
+    public static void closeAppenders(final Logger logger) {
+        final List<Appender> appenders = getAppenderList(logger);
+        for (Appender appender : appenders) {
+            if (appender instanceof AppenderAttachable) {
+                appender.close();
+            }
+        }
+    }
+
+    static CopyOnWriteArrayList<Appender> getAppenderList(final Logger logger) {
+        CopyOnWriteArrayList<Appender> result = logger.getAttachment(APPENDERS_KEY);
+        if (result == null) {
+            result = new CopyOnWriteArrayList<Appender>();
+            final CopyOnWriteArrayList<Appender> current;
+            if (System.getSecurityManager() == null) {
+                current = logger.attachIfAbsent(APPENDERS_KEY, result);
+            } else {
+                final CopyOnWriteArrayList<Appender> attachment = result;
+                current = AccessController.doPrivileged(new PrivilegedAction<CopyOnWriteArrayList<Appender>>() {
+                    @Override
+                    public CopyOnWriteArrayList<Appender> run() {
+                        return logger.attachIfAbsent(APPENDERS_KEY, attachment);
+                    }
+                });
+            }
+            if (current != null) {
+                result = current;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/apache/log4j/Hierarchy.java
+++ b/src/main/java/org/apache/log4j/Hierarchy.java
@@ -39,7 +39,6 @@ import org.apache.log4j.spi.LoggerRepository;
 import org.apache.log4j.spi.RendererSupport;
 import org.apache.log4j.spi.ThrowableRenderer;
 import org.apache.log4j.spi.ThrowableRendererSupport;
-import org.jboss.logmanager.LogContext;
 
 /**
  * Our replacement for the log4j {@code Hierarchy} class.  We redirect management of the hierarchy
@@ -55,7 +54,7 @@ public class Hierarchy implements LoggerRepository, RendererSupport, ThrowableRe
 
     public Hierarchy(Logger root) {
         listeners = new CopyOnWriteArraySet<HierarchyEventListener>();
-        jblmRootLogger = JBossLogManagerFacade.getJBossLogger(LogContext.getLogContext(), JBossLogManagerFacade.JBL_ROOT_NAME);
+        jblmRootLogger = JBossLogManagerFacade.getJBossLogger(JBossLogManagerFacade.JBL_ROOT_NAME);
         jblmRootLogger.setLevel(JBossLevelMapping.getLevelFor(root.getLevel()));
         defaultFactory = new DefaultCategoryFactory();
         rendererMap = new RendererMap();

--- a/src/main/java/org/apache/log4j/JBossAppenderHandler.java
+++ b/src/main/java/org/apache/log4j/JBossAppenderHandler.java
@@ -1,13 +1,7 @@
 package org.apache.log4j;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Handler;
 
-import org.apache.log4j.spi.AppenderAttachable;
 import org.apache.log4j.spi.LoggingEvent;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
@@ -24,11 +18,9 @@ import org.jboss.logmanager.Logger;
  */
 final class JBossAppenderHandler extends ExtHandler {
 
-    private static final org.jboss.logmanager.Logger.AttachmentKey<CopyOnWriteArrayList<Appender>> APPENDERS_KEY = new org.jboss.logmanager.Logger.AttachmentKey<CopyOnWriteArrayList<Appender>>();
-
     private final Logger logger;
 
-    private JBossAppenderHandler(final Logger logger) {
+    protected JBossAppenderHandler(final Logger logger) {
         this.logger = logger;
     }
 
@@ -36,7 +28,7 @@ final class JBossAppenderHandler extends ExtHandler {
     @Override
     protected void doPublish(final ExtLogRecord record) {
         final LoggingEvent event = new LoggingEvent(record, JBossLogManagerFacade.getLogger(logger));
-        final List<Appender> appenders = getAppenderList(logger);
+        final List<Appender> appenders = Appenders.getAppenderList(logger);
         for (Appender appender : appenders) {
             if (new JBossFilterWrapper(appender.getFilter(), true).isLoggable(record)) {
                 appender.doAppend(event);
@@ -51,7 +43,7 @@ final class JBossAppenderHandler extends ExtHandler {
     @Override
     public void close() throws SecurityException {
         checkAccess(this);
-        closeAppenders(logger);
+        Appenders.closeAppenders(logger);
     }
 
     @Override
@@ -79,136 +71,4 @@ final class JBossAppenderHandler extends ExtHandler {
         return new StringBuilder().append(getClass()).append("{").append(logger.getName()).append("}").toString();
     }
 
-    /**
-     * Attaches an appender to the logger.
-     *
-     * @param logger   the logger to attach the appender to.
-     * @param appender the appender to attach.
-     */
-    public static void attachAppender(final Logger logger, final Appender appender) {
-        Handler[] oldHandlers;
-        Handler[] newHandlers;
-        CAS:
-        do {
-            oldHandlers = logger.getHandlers();
-            for (Handler handler : oldHandlers) {
-                if (handler instanceof JBossAppenderHandler) {
-                    break CAS;
-                }
-            }
-            final int size = oldHandlers.length;
-            newHandlers = Arrays.copyOf(oldHandlers, size + 1);
-            newHandlers[size] = new JBossAppenderHandler(logger);
-        } while (!logger.compareAndSetHandlers(oldHandlers, newHandlers));
-        getAppenderList(logger).addIfAbsent(appender);
-    }
-
-    /**
-     * Retrieves all the appenders that are associated with this logger only.
-     *
-     * @param logger the logger to retrieve the appenders on.
-     *
-     * @return a collection of the appenders.
-     */
-    public static List<Appender> getAppenders(final Logger logger) {
-        List<Appender> appenders = getAppenderList(logger);
-        if (appenders == null) {
-            return Collections.emptyList();
-        }
-        return new ArrayList<Appender>(appenders);
-    }
-
-    /**
-     * Retrieves a single appender based on the appender name.
-     *
-     * @param logger the logger to check fot the appender.
-     * @param name   the name of the appender.
-     *
-     * @return the appender or {@code null} if the appender was not found.
-     */
-    public static Appender getAppender(final Logger logger, final String name) {
-        Appender result = null;
-        if (name != null) {
-            List<Appender> appenders = getAppenders(logger);
-            for (Appender appender : appenders) {
-                if (name.equals(appender.getName())) {
-                    result = appender;
-                    break;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Checks the logger to see if the appender is attached.
-     *
-     * @param logger   the logger to check for the appender.
-     * @param appender the appender to check for.
-     *
-     * @return {@code true} if the appender is found on the logger, otherwise {@code false}.
-     */
-    public static boolean isAppenderAttached(final Logger logger, final Appender appender) {
-        return getAppenders(logger).contains(appender);
-    }
-
-    /**
-     * Removes all the appenders from the logger and returns the all the appenders that were removed.
-     *
-     * @param logger the logger to remove the appenders from.
-     *
-     * @return a collection of the appenders that were removed.
-     */
-    public static List<Appender> removeAllAppenders(final Logger logger) {
-        List<Appender> result = Collections.emptyList();
-        final List<Appender> currentAppenders = getAppenderList(logger);
-        if (currentAppenders != null && !currentAppenders.isEmpty()) {
-            result = new ArrayList<Appender>(currentAppenders);
-            currentAppenders.clear();
-        }
-        return result;
-    }
-
-    /**
-     * Removes a single appender from the logger.
-     *
-     * @param logger   the logger to remove the appender from.
-     * @param appender the appender to remove.
-     *
-     * @return {@code true} if the appender wasn't {@code null} and was successfully removed, otherwise {@code false}.
-     */
-    public static boolean removeAppender(final Logger logger, final Appender appender) {
-        boolean result = false;
-        final List<Appender> currentAppenders = getAppenderList(logger);
-        if (currentAppenders != null) {
-            result = currentAppenders.remove(appender);
-        }
-        return result;
-    }
-
-    /**
-     * Closes the appenders attached to the logger if the appenders are an instance of {@link AppenderAttachable}.
-     *
-     * @param logger the logger to close the appenders on.
-     */
-    public static void closeAppenders(final Logger logger) {
-        final List<Appender> appenders = getAppenderList(logger);
-        for (Appender appender : appenders) {
-            if (appender instanceof AppenderAttachable) {
-                appender.close();
-            }
-        }
-    }
-
-    private static CopyOnWriteArrayList<Appender> getAppenderList(final Logger logger) {
-        CopyOnWriteArrayList<Appender> result = logger.getAttachment(APPENDERS_KEY);
-        if (result == null) {
-            result = new CopyOnWriteArrayList<Appender>();
-            final CopyOnWriteArrayList<Appender> current = logger.attachIfAbsent(APPENDERS_KEY, result);
-            if (current != null) {
-                result = current;
-            }
-        }
-        return result;
-    }
 }

--- a/src/main/java/org/apache/log4j/LogManager.java
+++ b/src/main/java/org/apache/log4j/LogManager.java
@@ -26,7 +26,6 @@ import java.util.Enumeration;
 import org.apache.log4j.spi.LoggerFactory;
 import org.apache.log4j.spi.LoggerRepository;
 import org.apache.log4j.spi.RepositorySelector;
-import org.jboss.logmanager.LogContext;
 
 public class LogManager {
     public static final String DEFAULT_CONFIGURATION_FILE = "log4j.properties";
@@ -47,7 +46,7 @@ public class LogManager {
     }
 
     public static LoggerRepository getLoggerRepository() {
-        return JBossLogManagerFacade.getLoggerRepository(LogContext.getLogContext());
+        return JBossLogManagerFacade.getLoggerRepository();
     }
 
     public static Logger getRootLogger() {


### PR DESCRIPTION
The `JBossLogManagerFacade` stores log4j information in attachments on the loggers. Attaching items to a logger requires `control` permissions for `java.util.logging.LoggingPermission`. Getting a log4j logger and creating the `Hierarchy` should be allowed even if permissions aren't granted by the security policy.

Getting the `LogContext` also has potential to throw a different permissions exception due to an `AtomicReferenceFieldUpdater` not having `accessDeclaredMembers` permissions.

```
Exception in thread "main" java.lang.ExceptionInInitializerError
    at org.jboss.logmanager.LogContext.<init>(LogContext.java:106)
    at org.jboss.logmanager.LogContext.<clinit>(LogContext.java:41)
    at org.apache.log4j.LogManager.getLoggerRepository(LogManager.java:50)
    at org.apache.log4j.LogManager.getLogger(LogManager.java:58)
    at org.apache.log4j.Logger.getLogger(Logger.java:39)
    at com.jamezp.test.Main.<clinit>(Main.java:19)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:270)
    at org.jboss.modules.Module.run(Module.java:302)
    at org.jboss.modules.Main.main(Main.java:460)
Caused by: java.lang.RuntimeException: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "accessDeclaredMembers")
    at java.util.concurrent.atomic.AtomicReferenceFieldUpdater$AtomicReferenceFieldUpdaterImpl.<init>(AtomicReferenceFieldUpdater.java:219)
    at java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater(AtomicReferenceFieldUpdater.java:95)
    at org.jboss.logmanager.LoggerNode.<clinit>(LoggerNode.java:87)
    ... 10 more
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "accessDeclaredMembers")
    at java.security.AccessControlContext.checkPermission(AccessControlContext.java:372)
    at java.security.AccessController.checkPermission(AccessController.java:559)
    at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
    at java.lang.Class.checkMemberAccess(Class.java:2237)
    at java.lang.Class.getDeclaredField(Class.java:1945)
    at java.util.concurrent.atomic.AtomicReferenceFieldUpdater$AtomicReferenceFieldUpdaterImpl.<init>(AtomicReferenceFieldUpdater.java:212)
    ... 12 more
```

While this only appears to happen during initialization of the first `LoggerNode` it seems safest to always wrap the access to it.

Moved appender support to it's own class as the `ExtHandler` throws exceptions the static handler updater isn't created in a privilege block.
