### PR TITLE
[LOGMGR-117] Fork Log4J ConosleAppender to simply handling of calls to Syetem.out

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
                                         <exclude>org/apache/log4j/Hierarchy$*.class</exclude>
                                         <exclude>org/apache/log4j/Category.class</exclude>
                                         <exclude>org/apache/log4j/Category$*.class</exclude>
+                                        <exclude>org/apache/log4j/ConsoleAppender.class</exclude>
+                                        <exclude>org/apache/log4j/ConsoleAppender$*.class</exclude>
                                         <exclude>org/apache/log4j/Logger.class</exclude>
                                         <exclude>org/apache/log4j/Logger$*.class</exclude>
                                         <exclude>org/apache/log4j/LogManager.class</exclude>

--- a/src/main/java/org/apache/log4j/ConsoleAppender.java
+++ b/src/main/java/org/apache/log4j/ConsoleAppender.java
@@ -1,0 +1,241 @@
+/*
+ * Modifications by Red Hat, Inc.
+ *
+ * This file incorporates work covered by the following notice(s):
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log4j;
+
+import java.io.BufferedOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.apache.log4j.helpers.LogLog;
+
+/**
+ * ConsoleAppender appends log events to <code>System.out</code> or
+ * <code>System.err</code> using a layout specified by the user. The
+ * default target is <code>System.out</code>.
+ *
+ * <p>
+ * <p>
+ *    Modification was done in JBoss fork to use the real <strong>stdout</strong>/<strong>stderr</strong>
+ *    via <code>FileDescriptor.out</code>/<code>FileDescriptor.err</code> instead of
+ *    <code>System.out</code>/<code>System.err</code>, because in some cases, the standard
+ *    stream may be reassigned.
+ * <p>
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Curt Arnold
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ * @since 1.1 */
+public class ConsoleAppender extends WriterAppender {
+
+  public static final String SYSTEM_OUT = "System.out";
+  public static final String SYSTEM_ERR = "System.err";
+
+  private static final PrintStream out =
+  new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out), 128), true);
+  private static final PrintStream err =
+  new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err), 128), true);
+
+  protected String target = SYSTEM_OUT;
+
+  /**
+   *  Determines if the appender honors reassignments of System.out
+   *  or System.err made after configuration.
+   */
+  private boolean follow = false;
+
+  /**
+    * Constructs an unconfigured appender.
+    */
+  public ConsoleAppender() {
+  }
+
+    /**
+     * Creates a configured appender.
+     *
+     * @param layout layout, may not be null.
+     */
+  public ConsoleAppender(Layout layout) {
+    this(layout, SYSTEM_OUT);
+  }
+
+    /**
+     *   Creates a configured appender.
+     * @param layout layout, may not be null.
+     * @param target target, either "System.err" or "System.out".
+     */
+  public ConsoleAppender(Layout layout, String target) {
+    setLayout(layout);
+    setTarget(target);
+    activateOptions();
+  }
+
+/**
+   *  Sets the value of the <b>Target</b> option. Recognized values
+   *  are "System.out" and "System.err". Any other value will be
+   *  ignored.
+   * */
+  public
+  void setTarget(String value) {
+    String v = value.trim();
+
+    if (SYSTEM_OUT.equalsIgnoreCase(v)) {
+      target = SYSTEM_OUT;
+    } else if (SYSTEM_ERR.equalsIgnoreCase(v)) {
+      target = SYSTEM_ERR;
+    } else {
+      targetWarn(value);
+    }
+  }
+
+  /**
+   * Returns the current value of the <b>Target</b> property. The
+   * default value of the option is "System.out".
+   *
+   * See also {@link #setTarget}.
+   * */
+  public
+  String getTarget() {
+    return target;
+  }
+
+  /**
+   *  Sets whether the appender honors reassignments of System.out
+   *  or System.err made after configuration.
+   *  @param newValue if true, appender will use value of System.out or
+   *  System.err in force at the time when logging events are appended.
+   *  @since 1.2.13
+   */
+  public final void setFollow(final boolean newValue) {
+     follow = newValue;
+  }
+
+  /**
+   *  Gets whether the appender honors reassignments of System.out
+   *  or System.err made after configuration.
+   *  @return true if appender will use value of System.out or
+   *  System.err in force at the time when logging events are appended.
+   *  @since 1.2.13
+   */
+  public final boolean getFollow() {
+      return follow;
+  }
+
+  void targetWarn(String val) {
+    LogLog.warn("["+val+"] should be System.out or System.err.");
+    LogLog.warn("Using previously set target, System.out by default.");
+  }
+
+  /**
+    *   Prepares the appender for use.
+    */
+   public void activateOptions() {
+        if (follow) {
+            if (target.equals(SYSTEM_ERR)) {
+               setWriter(createWriter(new SystemErrStream()));
+            } else {
+               setWriter(createWriter(new SystemOutStream()));
+            }
+        } else {
+            if (target.equals(SYSTEM_ERR)) {
+               setWriter(createWriter(err));
+            } else {
+               setWriter(createWriter(out));
+            }
+        }
+
+        super.activateOptions();
+  }
+
+  /**
+   *  {@inheritDoc}
+   */
+  protected
+  final
+  void closeWriter() {
+     if (follow) {
+        super.closeWriter();
+     }
+  }
+
+
+    /**
+     * An implementation of OutputStream that redirects to the
+     * current System.err.
+     *
+     */
+    private static class SystemErrStream extends OutputStream {
+        public SystemErrStream() {
+        }
+
+        public void close() {
+        }
+
+        public void flush() {
+            err.flush();
+        }
+
+        public void write(final byte[] b) throws IOException {
+            err.write(b);
+        }
+
+        public void write(final byte[] b, final int off, final int len)
+            throws IOException {
+            err.write(b, off, len);
+        }
+
+        public void write(final int b) throws IOException {
+            err.write(b);
+        }
+    }
+
+    /**
+     * An implementation of OutputStream that redirects to the
+     * current System.out.
+     *
+     */
+    private static class SystemOutStream extends OutputStream {
+        public SystemOutStream() {
+        }
+
+        public void close() {
+        }
+
+        public void flush() {
+            out.flush();
+        }
+
+        public void write(final byte[] b) throws IOException {
+            out.write(b);
+        }
+
+        public void write(final byte[] b, final int off, final int len)
+            throws IOException {
+            out.write(b, off, len);
+        }
+
+        public void write(final int b) throws IOException {
+            out.write(b);
+        }
+    }
+
+}


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/LOGMGR-117
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1196228

The commit contains a fork **ConsoleAppender** from log4j, it uses
 <code>new PrintStream(new FileOutputStream(FileDescriptor.out), true)</code>
 instead of    <code>System.out</code>  for the Console output.
