### PR TITLE
Null should be returned from the LoggingEvent.getThrowableInformation…

### DIFF
--- a/src/main/java/org/apache/log4j/spi/LoggingEvent.java
+++ b/src/main/java/org/apache/log4j/spi/LoggingEvent.java
@@ -227,14 +227,16 @@ public class LoggingEvent implements Serializable {
     }
 
     public ThrowableInformation getThrowableInformation() {
-        if (cachedThrowableInformation == null) {
-            cachedThrowableInformation = new ThrowableInformation(logRecord.getThrown(), logger);
+        final Throwable thrown = logRecord.getThrown();
+        if (cachedThrowableInformation == null && thrown != null) {
+            cachedThrowableInformation = new ThrowableInformation(thrown, logger);
         }
         return cachedThrowableInformation;
     }
 
     public String[] getThrowableStrRep() {
-        return getThrowableInformation().getThrowableStrRep();
+        final ThrowableInformation cachedThrowableInformation = getThrowableInformation();
+        return cachedThrowableInformation == null ? null : cachedThrowableInformation.getThrowableStrRep();
     }
 
     private void readObject(ObjectInputStream ois) throws java.io.IOException, ClassNotFoundException {

--- a/src/test/java/org/apache/log4j/LoggingEventTest.java
+++ b/src/test/java/org/apache/log4j/LoggingEventTest.java
@@ -27,9 +27,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
 
-import junit.framework.Assert;
 import org.apache.log4j.spi.LoggingEvent;
 import org.jboss.logmanager.ExtLogRecord;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -63,5 +63,30 @@ public class LoggingEventTest {
         } finally {
             objIn.close();
         }
+    }
+
+    @Test
+    public void testThrowableInformation() throws Exception {
+        final String category = "org.apache.log4j.test";
+        final Logger logger = Logger.getLogger(category);
+        final ExtLogRecord logRecord = new ExtLogRecord(org.jboss.logmanager.Level.INFO, "A test logging event", category);
+        LoggingEvent loggingEvent = new LoggingEvent(logRecord, logger);
+
+        Assert.assertNull("Expected the throwableInformation to be null", loggingEvent.getThrowableInformation());
+        Assert.assertNull(loggingEvent.getThrowableStrRep());
+
+        final RuntimeException thrown = new RuntimeException("testException");
+        logRecord.setThrown(thrown);
+        loggingEvent = new LoggingEvent(logRecord, logger);
+
+        Assert.assertNotNull(loggingEvent.getThrowableInformation());
+        Assert.assertNotNull(loggingEvent.getThrowableStrRep());
+        Assert.assertEquals(thrown, loggingEvent.getThrowableInformation().getThrowable());
+
+        loggingEvent = new LoggingEvent(LoggingEventTest.class.getName(), logger, Level.INFO, "A test logging event", thrown);
+
+        Assert.assertNotNull(loggingEvent.getThrowableInformation());
+        Assert.assertNotNull(loggingEvent.getThrowableStrRep());
+        Assert.assertEquals(thrown, loggingEvent.getThrowableInformation().getThrowable());
     }
 }


### PR DESCRIPTION
…() if the there was no logged exception.