### PR TITLE
[LOGMGR-166] Backport fix for CVE-2017-5645: Apache Log4j socket receiver deserialization vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
                                         <exclude>org/apache/log4j/NDC$*.class</exclude>
                                         <exclude>org/apache/log4j/helpers/Loader.class</exclude>
                                         <exclude>org/apache/log4j/helpers/Loader$*.class</exclude>
+                                        <exclude>org/apache/log4j/net/SocketNode.class</exclude>
                                         <exclude>org/apache/log4j/spi/LoggingEvent.class</exclude>
                                         <exclude>org/apache/log4j/spi/LoggingEvent$*.class</exclude>
                                         <exclude>org/apache/log4j/spi/NOPLogger.class</exclude>

--- a/src/main/java/org/apache/log4j/FilteredObjectInputStream.java
+++ b/src/main/java/org/apache/log4j/FilteredObjectInputStream.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.log4j;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Extended ObjectInputStream that only allows certain classes to be deserialized.
+ *
+ * Backported from 2.8.2
+ */
+public class FilteredObjectInputStream extends ObjectInputStream {
+
+    private static final List<String> REQUIRED_JAVA_CLASSES = Arrays.asList(
+            // Types of non-trainsient fields of LoggingEvent
+            "java.lang.String",
+            "java.util.Hashtable",
+            // ThrowableInformation
+            "[Ljava.lang.String;"
+    );
+
+    private final Collection<String> allowedClasses;
+
+    public FilteredObjectInputStream(final InputStream in, final Collection<String> allowedClasses) throws IOException {
+        super(in);
+        this.allowedClasses = allowedClasses;
+    }
+
+    @Override
+    protected Class<?> resolveClass(final ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        String name = desc.getName();
+        if (!(isAllowedByDefault(name) || allowedClasses.contains(name))) {
+            throw new InvalidObjectException("Class is not allowed for deserialization: " + name);
+        }
+        return super.resolveClass(desc);
+    }
+
+    private static boolean isAllowedByDefault(final String name) {
+        return name.startsWith("org.apache.log4j.") ||
+                name.startsWith("[org.apache.log4j.") ||
+                REQUIRED_JAVA_CLASSES.contains(name);
+    }
+
+}

--- a/src/main/java/org/apache/log4j/net/SocketNode.java
+++ b/src/main/java/org/apache/log4j/net/SocketNode.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.log4j.net;
+
+import org.apache.log4j.FilteredObjectInputStream;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggerRepository;
+import org.apache.log4j.spi.LoggingEvent;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.ObjectInputStream;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+// Contributors:  Moses Hohman <mmhohman@rainbow.uchicago.edu>
+
+/**
+   Read {@link LoggingEvent} objects sent from a remote client using
+   Sockets (TCP). These logging events are logged according to local
+   policy, as if they were generated locally.
+
+   <p>For example, the socket node might decide to log events to a
+   local file and also resent them to a second socket node.
+
+    @author  Ceki G&uuml;lc&uuml;
+
+    @since 0.8.4
+*/
+public class SocketNode implements Runnable {
+
+  Socket socket;
+  LoggerRepository hierarchy;
+  ObjectInputStream ois;
+
+  static Logger logger = Logger.getLogger(SocketNode.class);
+
+  public SocketNode(Socket socket, LoggerRepository hierarchy) {
+    this.socket = socket;
+    this.hierarchy = hierarchy;
+    try {
+      ois = new FilteredObjectInputStream(
+              new BufferedInputStream(socket.getInputStream()),
+              getAllowedClasses());
+    } catch(InterruptedIOException e) {
+      Thread.currentThread().interrupt();
+      logger.error("Could not open ObjectInputStream to "+socket, e);
+    } catch(IOException e) {
+      logger.error("Could not open ObjectInputStream to "+socket, e);
+    } catch(RuntimeException e) {
+      logger.error("Could not open ObjectInputStream to "+socket, e);
+    }
+  }
+
+  private Collection getAllowedClasses() {
+    Collection allowedClasses = new ArrayList();
+    String property = System.getProperty("org.apache.log4j.net.allowedClasses");
+    if (property != null)
+      allowedClasses.addAll(Arrays.asList(property.split(",")));
+    return allowedClasses;
+  }
+  //public
+  //void finalize() {
+  //System.err.println("-------------------------Finalize called");
+  // System.err.flush();
+  //}
+
+  public void run() {
+    LoggingEvent event;
+    Logger remoteLogger;
+
+    try {
+      if (ois != null) {
+          while(true) {
+	        // read an event from the wire
+	        event = (LoggingEvent) ois.readObject();
+	        // get a logger from the hierarchy. The name of the logger is taken to be the name contained in the event.
+	        remoteLogger = hierarchy.getLogger(event.getLoggerName());
+	        //event.logger = remoteLogger;
+	        // apply the logger-level filter
+	        if(event.getLevel().isGreaterOrEqual(remoteLogger.getEffectiveLevel())) {
+	        // finally log the event as if was generated locally
+	        remoteLogger.callAppenders(event);
+	      }
+        }
+      }
+    } catch(java.io.EOFException e) {
+      logger.info("Caught java.io.EOFException closing conneciton.");
+    } catch(java.net.SocketException e) {
+      logger.info("Caught java.net.SocketException closing conneciton.");
+    } catch(InterruptedIOException e) {
+      Thread.currentThread().interrupt();
+      logger.info("Caught java.io.InterruptedIOException: "+e);
+      logger.info("Closing connection.");
+    } catch(IOException e) {
+      logger.info("Caught java.io.IOException: "+e);
+      logger.info("Closing connection.");
+    } catch(Exception e) {
+      logger.error("Unexpected exception. Closing conneciton.", e);
+    } finally {
+      if (ois != null) {
+         try {
+            ois.close();
+         } catch(Exception e) {
+            logger.info("Could not close connection.", e);
+         }
+      }
+      if (socket != null) {
+        try {
+          socket.close();
+        } catch(InterruptedIOException e) {
+            Thread.currentThread().interrupt();
+        } catch(IOException ex) {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jira issues:
https://issues.jboss.org/browse/LOGMGR-166
https://issues.jboss.org/browse/JBEAP-11983