### PR TITLE
Check explicitly for a false value of the mail.smtp.ssl.checkserverid…

### DIFF
--- a/src/main/java/org/apache/log4j/net/SMTPAppender.java
+++ b/src/main/java/org/apache/log4j/net/SMTPAppender.java
@@ -230,7 +230,7 @@ public class SMTPAppender extends AppenderSkeleton
         String prefix = "mail.smtp";
         // If mail.smtp.ssl.checkserveridentity is not defined, default to true. See CVE-2020-9488
         final String currentValue = props.getProperty(prefix + ".ssl.checkserveridentity");
-        if (currentValue == null || currentValue.isEmpty()) {
+        if (!"false".equalsIgnoreCase(currentValue)) {
             props.put(prefix + ".ssl.checkserveridentity", "true");
         }
 


### PR DESCRIPTION
…entity. This feels like a safer approach.

Resolves #25