### PR TITLE
[LOGMGR-295] NTEventLogAppender is vulnerable to DLL Preloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
                                         <exclude>org/apache/log4j/net/SocketNode.class</exclude>
                                         <exclude>org/apache/log4j/net/SMTPAppender.class</exclude>
                                         <exclude>org/apache/log4j/net/SMTPAppender$*.class</exclude>
+                                        <exclude>org/apache/log4j/nt/NTEventLogAppender.class</exclude>
                                         <exclude>org/apache/log4j/spi/LoggingEvent.class</exclude>
                                         <exclude>org/apache/log4j/spi/LoggingEvent$*.class</exclude>
                                         <exclude>org/apache/log4j/spi/NOPLogger.class</exclude>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/LOGMGR-295
NexusIQ Reference: SONATYPE-2010-0053